### PR TITLE
Allow for the use of text format

### DIFF
--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -47,7 +47,7 @@ module Textris
       renderer.render(
         template: template_name,
         layout: false,
-        formats: [:html],
+        formats: [:html, :text],
         locale: @locale,
         assigns: set_instance_variables_for_rendering
       )


### PR DESCRIPTION
@danielpuglisi  A common use case for textris is to use .text.erb templates. Since SMS doesn't really support html.